### PR TITLE
fix: ruler UI alignment (#66)

### DIFF
--- a/app/components/timeline/TimelineRuler.tsx
+++ b/app/components/timeline/TimelineRuler.tsx
@@ -300,7 +300,7 @@ export const TimelineRuler: React.FC<TimelineRulerProps> = ({
           <div
             className="absolute bg-primary cursor-grab hover:cursor-grabbing z-50 border-2 border-background shadow-lg"
             style={{
-              left: `${rulerPositionPx - 6}px`,
+              left: `${rulerPositionPx - 5}px`,
               top: "1px",
               width: "12px",
               height: "10px",


### PR DESCRIPTION
Fixed the alignment of the timeline ruler as per the reference image in issue #66.

**Before:**  
![461449071-d6527aaa-a122-4d61-98e1-0baf0518b49b](https://github.com/user-attachments/assets/78117557-8771-4ef5-a857-4bfa72e437ce)
**After:**  
![Screenshot 2025-07-04 170306](https://github.com/user-attachments/assets/2ef7b9ec-e542-4487-9d16-07865d07e36b)

Closes #66