### PR TITLE
Removed Duplicate API calls and Hardcoded test user data

### DIFF
--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,5 +1,9 @@
 import React, { useRef, useEffect, useCallback, useState } from "react";
 import type { PlayerRef, CallbackListener } from "@remotion/player";
+import { redirect, useLoaderData, type LoaderFunctionArgs } from "react-router";
+import axios from "axios";
+import { requireUser } from "~/utils/auth.server";
+import type { PlayerRef, CallbackListener } from "@remotion/player";
 import {
   Play,
   Pause,
@@ -59,7 +63,15 @@ interface Message {
   timestamp: Date;
 }
 
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const res = await requireUser(request);
+  if (res.status !== 200) throw redirect("/login");
+  return { user: res.data };
+}
+
 export default function TimelineEditor() {
+  const { user } = useLoaderData<typeof loader>();
   const containerRef = useRef<HTMLDivElement>(null);
   const playerRef = useRef<PlayerRef>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -338,7 +350,7 @@ export default function TimelineEditor() {
       }
 
       const timelineState = getTimelineState();
-      await axios.put(`/ai/api/api/projects/${encodeURIComponent(id)}`, timelineState, {
+      await axios.put(`/ai/api/projects/${encodeURIComponent(id)}`, timelineState, {
         withCredentials: true,
       });
 
@@ -756,7 +768,7 @@ export default function TimelineEditor() {
           </Button>
 
           <ProfileMenu
-            user={{ name: "test", email: "test@test.com", image: "https://github.com/shadcn.png" }}
+            user={{ name: user.name ?? "", email: user.email ?? "", image: user.avatar_url ?? "" }}
             starCount={starCount}
             onSignOut={() => {}}
           />

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -3,7 +3,6 @@ import type { PlayerRef, CallbackListener } from "@remotion/player";
 import { redirect, useLoaderData, type LoaderFunctionArgs } from "react-router";
 import axios from "axios";
 import { requireUser } from "~/utils/auth.server";
-import type { PlayerRef, CallbackListener } from "@remotion/player";
 import {
   Play,
   Pause,
@@ -35,7 +34,6 @@ import { Switch } from "~/components/ui/switch";
 import { Label } from "~/components/ui/label";
 import { Input } from "~/components/ui/input";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "~/components/ui/resizable";
-import axios from "axios";
 import { toast } from "sonner";
 
 // Hooks

--- a/app/routes/projects.tsx
+++ b/app/routes/projects.tsx
@@ -58,7 +58,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   if (res.status !== 200) throw redirect("/login");
   const { origin } = new URL(request.url);
 
-  const projectsRes = await axios.get<{ projects: Project[] }>(`${origin}/ai/api/api/projects`, {
+  const projectsRes = await axios.get<{ projects: Project[] }>(`${origin}/ai/api/projects`, {
     headers: { Cookie: request.headers.get("Cookie") },
   });
 


### PR DESCRIPTION
Bug #1 — Duplicate /api/api/ in projects list API call

  - File: app/routes/projects.tsx:61
  - Issue: The axios GET call used ${origin}/ai/api/api/projects. The backend API router already has prefix /api, so this path resulted in a 404.
  - Fix: Changed to ${origin}/ai/api/projects

  Bug #2 — Duplicate /api/api/ in timeline save API call

  - File: app/routes/home.tsx:341
  - Issue: Same path duplication — axios.put('/ai/api/api/projects/...') — causing save operations to fail with 404.
  - Fix: Changed to /ai/api/projects/...

  Bug #3 — Hardcoded test user instead of real user data

  - File: app/routes/home.tsx:759
  - Issue: The ProfileMenu component received hardcoded fake data (name: "test", email: "test@test.com") instead of the actual logged-in user from
  the session.
  - Fix: Added a loader function that calls requireUser(request), returns the user, and redirects to /login on failure. The component now uses
  useLoaderData to get real user data (user.name, user.email, user.avatar_url).